### PR TITLE
use DFIBTC data series

### DIFF
--- a/src/app/components/dfi-statistics/dfi-statistics.component.ts
+++ b/src/app/components/dfi-statistics/dfi-statistics.component.ts
@@ -45,7 +45,7 @@ export class DfiStatisticsComponent implements OnInit, AfterViewInit {
         return 'BITTREX:DFIUSD/GBPUSD';
       }
       case 'BTC':  {
-        return 'BITTREX:DFIUSDT/BTCUSDT';
+        return 'BITTREX:DFIBTC';
       }
       case 'USDT':  {
         return 'BITTREX:DFIUSDT';


### PR DESCRIPTION
when charting `DFIBTC` on the TradingView it is possible to use directly the `DFIBTC` data points instead of `DFIUSDT/BTCUSDT`